### PR TITLE
[feat] API: デッキ作成・一覧取得 (POST/GET /decks)

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,2 +1,25 @@
 """CRUD operations for database models."""
 
+from sqlalchemy.orm import Session
+
+from models import Deck
+from schemas import DeckCreate
+
+
+def create_deck(db: Session, deck: DeckCreate) -> Deck:
+    """Create a new deck."""
+    db_deck = Deck(title=deck.title)
+    db.add(db_deck)
+    db.commit()
+    db.refresh(db_deck)
+    return db_deck
+
+
+def get_deck(db: Session, deck_id: int) -> Deck | None:
+    """Get a deck by ID."""
+    return db.query(Deck).filter(Deck.id == deck_id).first()
+
+
+def get_decks(db: Session, skip: int = 0, limit: int = 100) -> list[Deck]:
+    """Get all decks with pagination."""
+    return db.query(Deck).offset(skip).limit(limit).all()

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,16 @@
 
 from fastapi import FastAPI
 
+from database import Base, engine
+from routers import decks
+
+# Create database tables
+Base.metadata.create_all(bind=engine)
+
 app = FastAPI(title="FlashLearn API", version="0.1.0")
+
+# Include routers
+app.include_router(decks.router)
 
 
 @app.get("/")

--- a/backend/routers/decks.py
+++ b/backend/routers/decks.py
@@ -1,1 +1,45 @@
 """API routes for deck (問題集) management."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from crud import create_deck, get_deck, get_decks
+from database import get_db
+from schemas import DeckCreate, DeckResponse
+
+router = APIRouter(prefix="/decks", tags=["decks"])
+
+
+@router.post("", response_model=DeckResponse, status_code=status.HTTP_201_CREATED)
+async def create_deck_endpoint(
+    deck: DeckCreate,
+    db: Session = Depends(get_db),
+) -> DeckResponse:
+    """Create a new deck."""
+    return create_deck(db=db, deck=deck)
+
+
+@router.get("", response_model=list[DeckResponse])
+async def get_decks_endpoint(
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+) -> list[DeckResponse]:
+    """Get all decks with pagination."""
+    decks = get_decks(db=db, skip=skip, limit=limit)
+    return decks
+
+
+@router.get("/{deck_id}", response_model=DeckResponse)
+async def get_deck_endpoint(
+    deck_id: int,
+    db: Session = Depends(get_db),
+) -> DeckResponse:
+    """Get a deck by ID."""
+    deck = get_deck(db=db, deck_id=deck_id)
+    if deck is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Deck with id {deck_id} not found",
+        )
+    return deck


### PR DESCRIPTION
## 概要
デッキ（問題集）の作成と一覧取得のAPIエンドポイントを実装しました。

## 実装内容
- `backend/crud.py`: デッキ関連のCRUD関数を実装
  - `create_deck()` - デッキ作成
  - `get_deck()` - デッキ1件取得
  - `get_decks()` - デッキ一覧取得（ページネーション対応）
- `backend/routers/decks.py`: APIエンドポイントを実装
  - `POST /decks` - デッキ作成
  - `GET /decks` - デッキ一覧取得
  - `GET /decks/{deck_id}` - デッキ詳細取得
- `backend/main.py`: ルーターを登録し、データベーステーブル作成を追加

## 動作確認
- [x] コードの構文チェック完了
- [ ] Swagger UIでの動作確認（レビュー時に実施予定）

## 関連Issue
Closes #1