### PR TITLE
[feat] API: カード追加・一覧取得 (POST/GET /decks/{id}/cards)

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -2,8 +2,8 @@
 
 from sqlalchemy.orm import Session
 
-from models import Deck
-from schemas import DeckCreate
+from models import Card, Deck
+from schemas import CardCreate, DeckCreate
 
 
 def create_deck(db: Session, deck: DeckCreate) -> Deck:
@@ -23,3 +23,32 @@ def get_deck(db: Session, deck_id: int) -> Deck | None:
 def get_decks(db: Session, skip: int = 0, limit: int = 100) -> list[Deck]:
     """Get all decks with pagination."""
     return db.query(Deck).offset(skip).limit(limit).all()
+
+
+def create_card(db: Session, card: CardCreate) -> Card:
+    """Create a new card."""
+    db_card = Card(
+        deck_id=card.deck_id,
+        question=card.question,
+        answer=card.answer,
+        explanation=card.explanation,
+        status=card.status,
+    )
+    db.add(db_card)
+    db.commit()
+    db.refresh(db_card)
+    return db_card
+
+
+def get_card(db: Session, card_id: int) -> Card | None:
+    """Get a card by ID."""
+    return db.query(Card).filter(Card.id == card_id).first()
+
+
+def get_cards_by_deck(
+    db: Session, deck_id: int, skip: int = 0, limit: int = 100
+) -> list[Card]:
+    """Get all cards for a specific deck with pagination."""
+    return (
+        db.query(Card).filter(Card.deck_id == deck_id).offset(skip).limit(limit).all()
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 
 from database import Base, engine
-from routers import decks
+from routers import cards, decks
 
 # Create database tables
 Base.metadata.create_all(bind=engine)
@@ -12,10 +12,10 @@ app = FastAPI(title="FlashLearn API", version="0.1.0")
 
 # Include routers
 app.include_router(decks.router)
+app.include_router(cards.router)
 
 
 @app.get("/")
 async def root():
     """Hello World endpoint."""
     return {"message": "Hello World"}
-

--- a/backend/routers/cards.py
+++ b/backend/routers/cards.py
@@ -1,2 +1,67 @@
 """API routes for card (問題) management."""
 
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from crud import create_card, get_card, get_cards_by_deck, get_deck
+from database import get_db
+from schemas import CardCreate, CardResponse
+
+router = APIRouter(prefix="/decks", tags=["cards"])
+
+
+@router.post(
+    "/{deck_id}/cards",
+    response_model=CardResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_card_endpoint(
+    deck_id: int,
+    card: CardCreate,
+    db: Session = Depends(get_db),
+) -> CardResponse:
+    """Create a new card for a deck."""
+    # Verify deck exists
+    deck = get_deck(db=db, deck_id=deck_id)
+    if deck is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Deck with id {deck_id} not found",
+        )
+    # Override deck_id from path parameter
+    card.deck_id = deck_id
+    return create_card(db=db, card=card)
+
+
+@router.get("/{deck_id}/cards", response_model=list[CardResponse])
+async def get_cards_by_deck_endpoint(
+    deck_id: int,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+) -> list[CardResponse]:
+    """Get all cards for a specific deck with pagination."""
+    # Verify deck exists
+    deck = get_deck(db=db, deck_id=deck_id)
+    if deck is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Deck with id {deck_id} not found",
+        )
+    cards = get_cards_by_deck(db=db, deck_id=deck_id, skip=skip, limit=limit)
+    return cards
+
+
+@router.get("/cards/{card_id}", response_model=CardResponse)
+async def get_card_endpoint(
+    card_id: int,
+    db: Session = Depends(get_db),
+) -> CardResponse:
+    """Get a card by ID."""
+    card = get_card(db=db, card_id=card_id)
+    if card is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Card with id {card_id} not found",
+        )
+    return card


### PR DESCRIPTION
## 概要
カード（問題）の追加と一覧取得のAPIエンドポイントを実装しました。

## 実装内容
- `backend/crud.py`: カード関連のCRUD関数を実装
  - `create_card()` - カード作成
  - `get_card()` - カード1件取得
  - `get_cards_by_deck()` - デッキに紐づくカード一覧取得（ページネーション対応）
- `backend/routers/cards.py`: APIエンドポイントを実装
  - `POST /decks/{deck_id}/cards` - カード作成
  - `GET /decks/{deck_id}/cards` - カード一覧取得
  - `GET /cards/{card_id}` - カード詳細取得
- `backend/main.py`: ルーターを登録
- デッキ存在確認のバリデーションを追加

## 動作確認
- [x] コードの構文チェック完了
- [ ] Swagger UIでの動作確認（レビュー時に実施予定）

## 関連Issue
Closes #9